### PR TITLE
[Android 15+] Fix RemoteViews deserialization misalignment due to missing TypedObject header

### DIFF
--- a/app/src/main/java/com/example/thisseemswrong/FdLeaker.java
+++ b/app/src/main/java/com/example/thisseemswrong/FdLeaker.java
@@ -234,7 +234,7 @@ class FdLeaker {
             }
             ApplicationInfo applicationInfo = new ApplicationInfo();
             applicationInfo.packageName = "";
-            applicationInfo.writeToParcel(data, 0);
+            data.writeTypedObject(applicationInfo, 0);
             data.writeInt(0); // mIdealSize = null
             data.writeInt(0); // mLayoutId
             data.writeInt(0); // mViewId
@@ -566,7 +566,9 @@ class FdLeaker {
             }, 0);
             remoteViews.writeToParcel(data, 0);
             data.recycle();
-            sIntsInRemoteViewsBeforeAppInfo = probeOut[0] / 4;
+            // leading fields exclude the typed object sign
+            // per https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/os/Parcel.java;drc=61197364367c9e404c7da6900658f1b16c42d0da;l=2387
+            sIntsInRemoteViewsBeforeAppInfo = probeOut[0] / 4 - 1 ;
         } catch (NoSuchMethodException | IllegalAccessException |
                  InstantiationException | InvocationTargetException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
This PR fixes a logic bug in FdLeaker.java that caused RemoteViews deserialization to fail due to offset misalignment.

The Issue:
The original PoC calculated `sIntsInRemoteViewsBeforeAppInfo` based on the position inside `ApplicationInfo.writeToParcel`. 

However, `RemoteViews` uses `Parcel.writeTypedObject` to serialize the `ApplicationInfo` field, which prepends a 4-byte header (value 1) before the object data.

The original calculation included this header size in the "ints before AppInfo" count. Consequently, the payload construction loop wrote an extra 0 integer at the position where the TypedObject header was expected. This caused the receiver to:

- Read 0 via readTypedObject, interpreting the ApplicationInfo as null.
- Resume reading subsequent fields (like mIdealSize) from the current position, which actually contained the raw ApplicationInfo data.
- Fail due to data corruption and offset mismatch.

The Fix:

- Adjusted sIntsInRemoteViewsBeforeAppInfo calculation to subtract the 4-byte TypedObject header (- 1 int).
- Updated payload construction to use data.writeTypedObject(applicationInfo, 0) instead of direct writeToParcel. This ensures the correct non-null header (1) is written before the object data.

This ensures the `RemoteViews` structure is perfectly aligned and `ApplicationInfo` is correctly deserialized on the target.